### PR TITLE
refactor: redoable state

### DIFF
--- a/src/components/GpEditor.vue
+++ b/src/components/GpEditor.vue
@@ -20,6 +20,7 @@
       @input="handleContentChange"
       @keydown.tab="handleTab"
       @scroll="handleTextareaScroll"
+      @click="handleTextareaClick"
     />
   </div>
 </template>
@@ -46,6 +47,7 @@ let textarea = undefined
 
 const isInit = ref(false)
 const scrollIndex = ref(0)
+const textareaIndex = ref(0)
 
 const {
   value: model,
@@ -123,7 +125,7 @@ function handleContentChange (e) {
 
   setModel({
     value: e.target.value,
-    index: textarea.selectionEnd
+    index: e.target.selectionEnd
   })
 }
 
@@ -131,8 +133,8 @@ function handleTab (e) {
   e.preventDefault()
 
   const currentValue = model.value.value
-  const startIndex = textarea.selectionStart
-  const endIndex = textarea.selectionEnd
+  const startIndex = e.target.selectionStart
+  const endIndex = e.target.selectionEnd
   const newValue = currentValue.substring(0, startIndex) + '\t' + currentValue.substring(endIndex)
 
   updateTextareaValue(
@@ -147,6 +149,13 @@ function handleTab (e) {
 
 function handleTextareaScroll () {
   scrollIndex.value = textarea.scrollTop * -1
+}
+
+function handleTextareaClick (e) {
+  setModel({
+    value: model.value.value,
+    index: e.target.selectionEnd
+  })
 }
 </script>
 

--- a/src/components/GpEditor.vue
+++ b/src/components/GpEditor.vue
@@ -26,7 +26,7 @@
 
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue'
-import { useStack } from '../composables/stack'
+import { useRedoable } from '../composables/redoable'
 
 const props = defineProps({
   modelValue: {
@@ -44,28 +44,36 @@ const emit = defineEmits(['update:modelValue'])
 // textarea instance
 let textarea = undefined
 
+const isInit = ref(false)
 const scrollIndex = ref(0)
 
 const {
-  pop: undoPop,
-  push: undoPush
-} = useStack()
-
-const {
-  pop: redoPop,
-  push: redoPush
-} = useStack()
-
-const content = computed({
-  get: _ => props.modelValue,
-  set: value => emit('update:modelValue', value)
+  value: model,
+  setValue: setModel,
+  undo: undoModel,
+  redo: redoModel
+} = useRedoable({
+  value: '',
+  index: 0
 })
 
-const lines = computed(() => content.value.split('\n').length)
+const lines = computed(() => model.value.value.split('\n').length)
 
-watch(props, _ => {
-  textarea.value = props.modelValue
-  content.value = props.modelValue
+watch(model, _ => {
+  emit('update:modelValue', model.value.value)
+})
+
+watch(props, (value) => {
+  if (isInit.value) {
+    return
+  }
+
+  setModel({
+    value: value.modelValue,
+    index: 0
+  })
+  updateTextareaValue(value.modelValue, 0)
+  isInit.value = true
 })
 
 onMounted(() => {
@@ -95,49 +103,32 @@ function updateTextareaValue (value, index) {
 }
 
 function undoChange () {
-  const previous = undoPop()
-  if (!previous) return
+  if (!undoModel()) {
+    return
+  }
 
-  redoPush({
-    value: content.value,
-    index: textarea.selectionEnd
-  })
-  updateTextareaValue(previous.value, previous.index)
-  content.value = previous.value
+  updateTextareaValue(model.value.value, model.value.index)
 }
 
 function redoChange () {
-  const previous = redoPop()
-  if (!previous) return
+  if (!redoModel())
 
-  undoPush({
-    value: content.value,
-    index: textarea.selectionEnd
-  })
-  updateTextareaValue(previous.value, previous.index)
-  content.value = previous.value
+  updateTextareaValue(model.value.value, model.value.index)
 }
 
 function handleContentChange (e) {
   e.preventDefault()
 
-  undoPush({
-    value: content.value,
-    index: textarea.selectionEnd - 1
+  setModel({
+    value: e.target.value,
+    index: textarea.selectionEnd
   })
-
-  content.value = e.target.value
 }
 
 function handleTab (e) {
   e.preventDefault()
 
-  undoPush({
-    value: textarea.value,
-    index: textarea.selectionEnd
-  })
-
-  const currentValue = content.value
+  const currentValue = model.value.value
   const startIndex = textarea.selectionStart
   const endIndex = textarea.selectionEnd
   const newValue = currentValue.substring(0, startIndex) + '\t' + currentValue.substring(endIndex)
@@ -147,7 +138,10 @@ function handleTab (e) {
     endIndex + 1
   )
 
-  content.value = newValue
+  setModel({
+    value: newValue,
+    index: endIndex + 1
+  })
 }
 
 function handleTextareaScroll () {

--- a/src/components/GpEditor.vue
+++ b/src/components/GpEditor.vue
@@ -68,11 +68,11 @@ watch(props, (value) => {
     return
   }
 
+  updateTextareaValue(value.modelValue, 0)
   setModel({
     value: value.modelValue,
     index: 0
   })
-  updateTextareaValue(value.modelValue, 0)
   isInit.value = true
 })
 
@@ -111,7 +111,9 @@ function undoChange () {
 }
 
 function redoChange () {
-  if (!redoModel())
+  if (!redoModel()) {
+    return
+  }
 
   updateTextareaValue(model.value.value, model.value.index)
 }
@@ -137,7 +139,6 @@ function handleTab (e) {
     newValue,
     endIndex + 1
   )
-
   setModel({
     value: newValue,
     index: endIndex + 1

--- a/src/composables/redoable.js
+++ b/src/composables/redoable.js
@@ -1,0 +1,39 @@
+import { computed, reactive } from 'vue'
+
+export function useRedoable (initial) {
+  const undoHist = []
+  const redoHist = []
+  const state = reactive({ value: initial })
+
+  const currentValue = computed(() => state.value)
+
+  function setValue (value) {
+    undoHist.unshift(state.value)
+    state.value = value
+  }
+
+  function undo () {
+    if (undoHist.length === 0) {
+      return
+    }
+
+    redoHist.unshift(state.value)
+    state.value = undoHist.shift()
+  }
+
+  function redo () {
+    if (redoHist.length === 0) {
+      return
+    }
+
+    undoHist.unshift(state.value)
+    state.value = redoHist.shift()
+  }
+
+  return {
+    value: currentValue,
+    setValue,
+    undo,
+    redo
+  }
+}

--- a/src/composables/redoable.js
+++ b/src/composables/redoable.js
@@ -14,20 +14,24 @@ export function useRedoable (initial) {
 
   function undo () {
     if (undoHist.length === 0) {
-      return
+      return false
     }
 
     redoHist.unshift(state.value)
     state.value = undoHist.shift()
+
+    return true
   }
 
   function redo () {
     if (redoHist.length === 0) {
-      return
+      return false
     }
 
     undoHist.unshift(state.value)
     state.value = redoHist.shift()
+
+    return true
   }
 
   return {

--- a/src/composables/redoable.test.js
+++ b/src/composables/redoable.test.js
@@ -1,0 +1,30 @@
+import { test, assert } from 'vitest'
+import { useRedoable } from './redoable'
+
+test.concurrent('useRedoable', () => {
+  const { value, setValue, undo, redo } = useRedoable({ text: '' })
+
+  setValue({ text: 'First' })
+  assert.equal(value.value.text, 'First')
+
+  setValue({ text: 'Second' })
+  assert.equal(value.value.text, 'Second')
+
+  undo()
+  assert.equal(value.value.text, 'First')
+
+  undo()
+  assert.equal(value.value.text, '')
+
+  redo()
+  assert.equal(value.value.text, 'First')
+
+  redo()
+  assert.equal(value.value.text, 'Second')
+
+  redo()
+  assert.equal(value.value.text, 'Second')
+
+  undo()
+  assert.equal(value.value.text, 'First')
+}, 1000)


### PR DESCRIPTION
Wrap the textarea content with `useRedoable` to bloat `GpEditor` less